### PR TITLE
Add filtering and route planning features

### DIFF
--- a/Javascript
+++ b/Javascript
@@ -66,6 +66,20 @@ fetch('https://6f6twe9e95.execute-api.eu-north-1.amazonaws.com/default/getTfnDat
         iconAnchor: [17, 44.5],
         popupAnchor: [0, -45]
     });
+
+    // Larger icons for highlighting on planned routes
+    var r2sBig = L.icon({
+        iconUrl: 'https://tfn.co.za/wp-content/uploads/2024/09/r2s.svg',
+        iconSize: [50, 65],
+        iconAnchor: [25, 65],
+        popupAnchor: [0, -65]
+    });
+    var r2sPlusBig = L.icon({
+        iconUrl: 'https://tfn.co.za/wp-content/uploads/2024/09/r2sPlus.svg',
+        iconSize: [50, 65],
+        iconAnchor: [25, 65],
+        popupAnchor: [0, -65]
+    });
     
     // Iterate through the locations array and add markers to the map
     locations.forEach(location => {
@@ -97,14 +111,23 @@ fetch('https://6f6twe9e95.execute-api.eu-north-1.amazonaws.com/default/getTfnDat
       })
       products += "</ul>";
       var marker = L.marker([GPSLatitude, GPSLongitude], {
-      	icon: mapIcon,
+        icon: mapIcon,
         title: "Depot"
       }).bindPopup(`<h6 style="max-width: 15ch; text-wrap: balance;">${location.Title}</h6>
         Type: <strong>${site}</strong><br>
         Base Price: <sup>R</sup><strong>${location.price}</strong><br>
         <a target="_blank" href="http://maps.google.com/maps?ll=${GPSLatitude},${GPSLongitude}">Open in Google Maps</a><br><br>${products}`).addTo(map);
-    	marker.depotData = location;
-    	// marker.bindTooltip("my tooltip text").openTooltip();
+        marker.depotData = location;
+        marker.depotType = site;
+        marker.originalIcon = mapIcon;
+        if (site === "Refuel2Save") {
+            marker.bigIcon = r2sBig;
+        } else if (site === "Refuel2Save+") {
+            marker.bigIcon = r2sPlusBig;
+        } else {
+            marker.bigIcon = mapIcon;
+        }
+        // marker.bindTooltip("my tooltip text").openTooltip();
       loTotal ++;
       markers.push(marker);
     });
@@ -156,6 +179,23 @@ fetch('https://6f6twe9e95.execute-api.eu-north-1.amazonaws.com/default/getTfnDat
       }
       filterCount.innerText = loCount;
       console.log(markers);
+    });
+
+    // Pricing filter
+    var priceDropdown = document.getElementById('priceFilter');
+    priceDropdown.addEventListener('change', function() {
+      var selectedPrice = this.value;
+      var loCount = 0;
+
+      markers.forEach(function(marker) {
+        if (selectedPrice === 'all' || marker.depotType === selectedPrice) {
+          marker.addTo(map);
+          loCount++;
+        } else {
+          marker.remove();
+        }
+      });
+      filterCount.innerText = loCount;
     });
     
     // minimal configure
@@ -286,4 +326,70 @@ routeBtns.forEach((route) => {
         }
     })
 })
+
+// Depot name search filtering
+let depotSearch = document.getElementById("depotSearch");
+depotSearch.addEventListener("input", function() {
+    var query = this.value.toLowerCase();
+    var loCount = 0;
+    markers.forEach(function(marker) {
+        var title = marker.depotData.Title.toLowerCase();
+        if (query === "" || title.includes(query)) {
+            marker.addTo(map);
+            loCount++;
+        } else {
+            marker.remove();
+        }
+    });
+    filterCount.innerText = loCount;
+});
+
+// Route planning
+let planBtn = document.getElementById("planRoute");
+let startInput = document.getElementById("routeStart");
+let endInput = document.getElementById("routeEnd");
+let routeLine;
+
+async function geocode(place) {
+    const url = `https://nominatim.openstreetmap.org/search?format=geojson&limit=1&q=${encodeURIComponent(place)}`;
+    const data = await fetch(url).then(r => r.json());
+    if (data.features && data.features.length) {
+        const [lng, lat] = data.features[0].geometry.coordinates;
+        return {lat, lng};
+    }
+    return null;
+}
+
+planBtn.addEventListener("click", async function() {
+    const startVal = startInput.value;
+    const endVal = endInput.value;
+    if (!startVal || !endVal) return;
+
+    const start = await geocode(startVal);
+    const end = await geocode(endVal);
+    if (!start || !end) return;
+
+    const routeUrl = `https://router.project-osrm.org/route/v1/driving/${start.lng},${start.lat};${end.lng},${end.lat}?overview=full&geometries=geojson`;
+    const routeData = await fetch(routeUrl).then(r => r.json());
+    if (!routeData.routes || !routeData.routes.length) return;
+
+    const coords = routeData.routes[0].geometry.coordinates.map(p => [p[1], p[0]]);
+    if (routeLine) map.removeLayer(routeLine);
+    routeLine = L.polyline(coords, {color: 'blue', weight: 4}).addTo(map);
+    map.fitBounds(routeLine.getBounds());
+
+    var bounds = routeLine.getBounds().pad(0.05);
+    var loCount = 0;
+    markers.forEach(function(marker) {
+        if (bounds.contains(marker.getLatLng())) {
+            marker.addTo(map);
+            marker.setIcon(marker.bigIcon);
+            loCount++;
+        } else {
+            marker.remove();
+            marker.setIcon(marker.originalIcon);
+        }
+    });
+    filterCount.innerText = loCount;
+});
 </script>


### PR DESCRIPTION
## Summary
- extend Leaflet setup with larger highlight icons
- record depot type for each marker
- add price filtering functionality
- add depot name search filtering
- implement basic route planning via OSRM with markers enlarged on the route

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688b179cc5f48330a3ebe9382f546761